### PR TITLE
If not on mobile, quit with informative log msg

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ export default class AdvancedToolbar extends Plugin {
 	}
 
 	async onload() {
-		console.log('loading plugin');
+		console.log('Loading Advanced Mobile Toolbar plugin.');
 
 		await this.loadSettings();
 
@@ -34,6 +34,10 @@ export default class AdvancedToolbar extends Plugin {
 			//This supposedly fires when the View Mode Changes from Preview to Source and Vice Versa
 			this.registerEvent(this.app.workspace.on("layout-change", this.toolbarHandler));
 			//this.app.workspace.on("active-leaf-change", () => {});
+		}
+		else {
+			console.log('Advanced Mobile Toolbar detected desktop Obsidian and is aborting. You still have access to change the settings.')
+			return
 		}
 
 		addFeatherIcons(this.iconList);
@@ -64,7 +68,7 @@ export default class AdvancedToolbar extends Plugin {
 	}
 
 	onunload() {
-		console.log('unloading plugin');
+		console.log('Unloading Advanced Mobile Toolbar plugin.');
 	}
 
 	async loadSettings() {


### PR DESCRIPTION
The current `onload()` tries to make use of `this.app.mobileToolbar` without checking that it actually exists, which leads to an error in the console that's confusing unless you know what it is (I sorted through every plugin to find what was causing it). This change allows the platform check that's already in place to stop the rest of the plugin from trying to happen, and also makes the load and unload messages reflect the identity of the plugin.